### PR TITLE
Re-add python 3.6 testing on travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,7 +15,6 @@ before_install:
   - sudo apt-get update -qq
   - sudo apt-get install -qq -y libdb5.1-dev
   - pip install -U setuptools
-  - pip list
 
 env:
   - TARGET=lint

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,10 +9,13 @@ addons:
 
 python:
   - "3.5"
+  - "3.6"
 
 before_install:
   - sudo apt-get update -qq
   - sudo apt-get install -qq -y libdb5.1-dev
+  - pip install -U setuptools
+  - pip list
 
 env:
   - TARGET=lint

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,4 @@
+dist: trusty
 language: python
 
 addons:

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
-Gutenberg==0.6.0
+Gutenberg==0.6.1
 sanic==0.5.2

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
-Gutenberg==0.5.0
+Gutenberg==0.6.0
 sanic==0.5.2


### PR DESCRIPTION
  Blocked by PR on Gutenberg for fix on using setuptools 38.0+. Once that's merged, we should be able to re-run the test suite for the second commit and everything should be hunky dory.